### PR TITLE
Update call to deprecated function neobundle#rc()

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -13,7 +13,7 @@ scriptencoding utf-8
 "=============================================
 
 " Load neobundle
-call neobundle#rc(expand('~/.vim/bundle/'))
+call neobundle#begin(expand('~/.vim/bundle/'))
 
 NeoBundleFetch 'Shougo/neobundle.vim'
 
@@ -29,6 +29,8 @@ NeoBundle 'vim-scripts/matchit.zip'
 
 " Check for missing packages
 NeoBundleCheck
+
+call neobundle#end()
 
 " Load plugins
 filetype plugin indent on


### PR DESCRIPTION
Neobundle was complaining each time vim started with the following
messages:

[neobundle] neobundle#rc() is deprecated function.
[neobundle] It will be removed in the next version.
[neobundle] Please use neobundle#begin()/neobundle#end() instead.

This patch simply updates the function call as directed by the output.
