### PR TITLE
Sync history file between bash sessions

### DIFF
--- a/.bashrc.d/10-environment
+++ b/.bashrc.d/10-environment
@@ -4,10 +4,16 @@
 EDITOR="vim"
 CLICOLOR=1
 HISTSIZE=10000
-HISTCONTROL=erasedups
+HISTCONTROL=ignoredups:erasedups
+
+# After each command, save and reload history
+PROMPT_COMMAND="history -a; history -c; history -r; $PROMPT_COMMAND"
 
 # Better globbing in bash
 shopt -s globstar
+
+# Append history entries
+shopt -s histappend
 
 # Disable Ctrl-s suspend terminal
 stty -ixon
@@ -31,4 +37,4 @@ fi
 
 prepend_path "${HOME}/bin"
 
-export EDITOR CLICOLOR HISTSIZE HISTCONTROL
+export EDITOR CLICOLOR HISTSIZE HISTCONTROL PROMPT_COMMAND


### PR DESCRIPTION
When using multiple bash sessions at the same time the history file gets
out of sync and you can not recall commands from other sessions. This
change syncs the history file between sessions. If you need a command
immediately in another session you may have to press enter once to get
it to sync up the history since this is done using "PROMPT_COMMAND".
